### PR TITLE
Promote dev

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "chbx",
     "firebaserc",
     "hostingchannels",
+    "mapserv",
     "Merc",
     "overriden",
     "proenv",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.5.8-0](https://github.com/agrc/raster/compare/v2.5.7...v2.5.8-0) (2025-06-04)
+
+
+### Bug Fixes
+
+* test cloud mapserv replacement ([4313a31](https://github.com/agrc/raster/commit/4313a3174e6e0f5031b98703b0ea4d8d0e9228e0))
+
 ## [2.5.7](https://github.com/agrc/raster/compare/v2.5.6...v2.5.7) (2025-05-20)
 
 

--- a/_src/app/config.js
+++ b/_src/app/config.js
@@ -87,6 +87,8 @@ define([
         // *.dev.utah.gov
         config.apiKey = 'AGRC-FE1B257E901672';
         config.quadWord = 'wedding-tactic-enrico-yes';
+        config.urls.mapService = 'https://mapserv.dev.utah.gov/arcgis/rest/services/Raster/MapServer';
+        esriConfig.defaults.io.corsEnabledServers.push('mapserv.dev.utah.gov');
     } else {
         xhr(require.baseUrl + 'secrets.json', {
             handleAs: 'json',

--- a/_src/app/config.js
+++ b/_src/app/config.js
@@ -12,7 +12,7 @@ define([
 ) {
     var config = {
         appName: 'Raster',
-        version: '2.5.7', // x-release-please-version
+        version: '2.5.8-0', // x-release-please-version
         wkid: 3857,
         urls: {
             mapService: 'https://mapserv.utah.gov/arcgis/rest/services/Raster/MapServer',

--- a/_src/app/templates/Toolbox.html
+++ b/_src/app/templates/Toolbox.html
@@ -180,7 +180,7 @@
                     Mouse Scroll Forward to zoom in<br>
                     Mouse Scroll Backward to zoom out<br>
                     <hr>
-                    <a href='https://gis.utah.gov/data/base-map-and-imagery/' target="_blank">Utah SGID Image Service Info</a>
+                    <a href='https://gis.utah.gov/products/sgid/base-maps/' target="_blank">UGRC basemap information</a>
                 </div>
             </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raster",
-  "version": "2.5.7",
+  "version": "2.5.8-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raster",
-      "version": "2.5.7",
+      "version": "2.5.8-0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raster",
-  "version": "2.5.7",
+  "version": "2.5.8-0",
   "description": "Raster Discovery App",
   "main": "src/index.html",
   "repository": {


### PR DESCRIPTION
this deploy isn't 100% necessary but it does fix the link in the bottom. 

We'd most likely want to remove the staging dev dns addition for future dev deploys. I'm not sure how you manage service changes in dev now.